### PR TITLE
修改函数 _read_reply() 

### DIFF
--- a/lib/resty/ssdb.lua
+++ b/lib/resty/ssdb.lua
@@ -108,6 +108,7 @@ end
 
 local function _read_reply(sock)
 	local val = {}
+    local ret = nil
 
 	while true do
 		-- read block size
@@ -119,21 +120,25 @@ local function _read_reply(sock)
 		local d_len = tonumber(line)
 
 		-- read block data
-		local data, err, partial = sock:receive(d_len)
-		insert(val, data);
+		local data, err = sock:receive(d_len)
+        if not data then
+            return nil, err
+        end
+		insert(val, data)
 
-		-- ignore the trailing lf/crlf after block data
-		local line, err, partial = sock:receive()
+		local dummy, err = sock:receive(1) -- ignore LF
+        if not dummy then
+            return nil, err
+        end
 	end
 
-	local v_num = tonumber(#val)
+    if val[1] == 'not_found' then
+        ret = null
+    elseif val[1] == 'ok' and val[2] then
+        ret = val[2]
+    end
 
-	if v_num == 1 then
-		return val
-	else
-		remove(val,1)
-		return val
-	end
+    return ret
 end
 
 


### PR DESCRIPTION
1、返回值从array改为string。保持和redis一致；
2、处理key在ssdb不存在的情况，返回ngx.null而不是字符串'not found'；
3、增加对sock:receive()返回值的错误处理。
